### PR TITLE
Add BigQuery to community adapter list

### DIFF
--- a/src/docs/adapters.md
+++ b/src/docs/adapters.md
@@ -26,4 +26,5 @@ Core adapters are created and maintained by the maintainers of Harlequin.
 
 Community adapters are created and maintained by other members of the Harlequin community. To add your adapter to this list, please [open a PR](https://github.com/tconbeer/harlequin-web).
 
+- [BigQuery](https://github.com/joshtemple/harlequin-bigquery)
 - ClickHouse (Coming Soon!)


### PR DESCRIPTION
@tconbeer do want me to add an adapter page as well, similar to what you've done for the core adapters?