### PR TITLE
Update key-bindings.md

### DIFF
--- a/src/docs/troubleshooting/key-bindings.md
+++ b/src/docs/troubleshooting/key-bindings.md
@@ -15,6 +15,8 @@ If you don't want to [upgrade your terminal](terminal-recommendations), you can 
 <!-- prettier-ignore -->
 - Comment line: use <Key>ctrl+_</Key> (underscore), not <Key>ctrl+/</Key>.
 - On a Mac: For all bindings, use <Key>^ Control</Key>, not <Key>⌘ Command</Key>.
+    - On MacOs >= 15.0.0 , the key binding <Key>^+enter</Key> is mapped to "Show contextual menu" by default. This interferes with the "Run Query" key binding of Harlequin. Instead of setting up alternative key bindings, you can disable this shortcut in MacOS under: 
+`System Settings -> Keyboard -> Keyboard Shortcuts... -> Keyboard -> turn "Show contextual menu" off`
 
 [See here](copying-and-pasting) for copy and paste.
 

--- a/src/docs/troubleshooting/key-bindings.md
+++ b/src/docs/troubleshooting/key-bindings.md
@@ -15,8 +15,7 @@ If you don't want to [upgrade your terminal](terminal-recommendations), you can 
 <!-- prettier-ignore -->
 - Comment line: use <Key>ctrl+_</Key> (underscore), not <Key>ctrl+/</Key>.
 - On a Mac: For all bindings, use <Key>^ Control</Key>, not <Key>⌘ Command</Key>.
-    - On MacOs >= 15.0.0 , the key binding <Key>^+enter</Key> is mapped to "Show contextual menu" by default. This interferes with the "Run Query" key binding of Harlequin. Instead of setting up alternative key bindings, you can disable this shortcut in MacOS under: 
-`System Settings -> Keyboard -> Keyboard Shortcuts... -> Keyboard -> turn "Show contextual menu" off`
+    - On MacOs >= 15.0.0 , the key binding <Key>^+enter</Key> is mapped to "Show contextual menu" by default. This interferes with the "Run Query" key binding of Harlequin. Instead of setting up alternative key bindings, you can disable this shortcut in MacOS by navigating to: System Settings -> Keyboard -> Keyboard Shortcuts... -> Keyboard -> turn "Show contextual menu" off.
 
 [See here](copying-and-pasting) for copy and paste.
 


### PR DESCRIPTION
This is my first pull request on a public repo, if I don't follow the right etiquette let me know. 


issue: the key binding ctrl+enter on Mac is set, by default, to the function "show contextual menu". This interferes with the "run query" function of Harlequin. Where to disable this key binding in macOS is not trivial

added: small explanation about the ctrl+enter behavior + the path in system settings where to disable this option