### PR TITLE
chore: change trino adapter link

### DIFF
--- a/src/routes/docs/[topic]/[[page]]/+page.server.ts
+++ b/src/routes/docs/[topic]/[[page]]/+page.server.ts
@@ -17,7 +17,7 @@ export async function load({ fetch, params }) {
     mysql: "tconbeer/harlequin-mysql",
     odbc: "tconbeer/harlequin-odbc",
     bigquery: "joshtemple/harlequin-bigquery",
-    trino: "TylerHillery/harlequin-trino",
+    trino: "rogerioguicampos/harlequin-trino",
     databricks: "alexmalins/harlequin-databricks",
     adbc: "TylerHillery/harlequin-adbc",
     risingwave: "zen-xu/harlequin-risingwave",


### PR DESCRIPTION
I have transferred ownership of the harlequin-trino to @rogerioguicampos who was kind of enough to take over this project for me. Updating the link to make sure it points to the new github repo.