### PR TITLE
Fix the hsql flags that do not exist

### DIFF
--- a/src/docs/getting-started/hsql.md
+++ b/src/docs/getting-started/hsql.md
@@ -85,7 +85,7 @@ hsql supports a number of options for setting the query limit, configuring outpu
 ```bash
 hsql -P prod -c "select count(*) from orders" --csv
 hsql -P dev -c "select * from users" --vertical --limit 5
-hsql -P warehouse -c "..." --parquet -o invoices.pq
+hsql -P warehouse -c "..." --format parquet -o invoices.pq
 ```
 
 ## Data Layouts and File Formats
@@ -131,7 +131,7 @@ that message so do NOT use hsql with <code>2>/dev/null</code>.
 hsql can write data to files, either with the `-o` option or by piping output (hsql only writes data to stdout; other messages go to stderr):
 
 ```bash
-hsql -P prod --limit -1 -c "select * from users" --parquet -o "users.pq"
+hsql -P prod --limit -1 -c "select * from users" --format parquet -o "users.pq"
 hsql -P prod --limit -1 -c "select * from users" --csv > users.csv
 ```
 
@@ -140,13 +140,13 @@ hsql can execute multiple statements in one invocation, and supports several met
 - Pass `-c` multiple times
 - Include multiple queries, separated by `;`, in one `-c` option
 - Pass one or more .sql files with `-f`, with multiple statements in each
-- Use `--results` to define which queries output data to stdout
+- Use `--result` to define which queries output data to stdout
 - Use `--on-error` to either `stop` or `continue` if one or more queries produces an error.
 
 In other words, this works:
 
 ```bash
-hsql -P prod --limit -1 --format md --results all --on-error stop \
+hsql -P prod --limit -1 --format md --result all --on-error stop \
     -f ./setup.sql \
     -c "select count(*) from raw_table" \
     -f ./build-models.sql \

--- a/src/routes/hsql_features.svelte
+++ b/src/routes/hsql_features.svelte
@@ -6,7 +6,7 @@
     { text: 'hsql -P dev -tAc "select 1"', kind: "command" },
     { text: "1" },
     {
-      text: `hsql -P prod --results all --on-error stop \\
+      text: `hsql -P prod --result all --on-error stop \\
   -f ./setup.sql \\
   -c "select count(*) as raw from raw_table" \\
   -f ./build-models.sql \\


### PR DESCRIPTION
The site documents two hsql flags that aren't real. Both exit `2` with `No such option`, so every one of these is a copy-paste-and-fail:

```
$ hsql -c "select 1" --parquet -o out.pq
Error: No such option '--parquet'. Did you mean '--path'?

$ hsql -c "select 1" --results all
Error: No such option '--results'. (Did you mean one of: '--result', '--stats'?)
```

Five occurrences, corrected to the spellings hsql has always had:

| where | was | now |
| --- | --- | --- |
| `src/docs/getting-started/hsql.md:88` | `--parquet -o invoices.pq` | `--format parquet -o invoices.pq` |
| `src/docs/getting-started/hsql.md:134` | `--parquet -o "users.pq"` | `--format parquet -o "users.pq"` |
| `src/docs/getting-started/hsql.md:143` | Use `--results` to define… | Use `--result` to define… |
| `src/docs/getting-started/hsql.md:149` | `--format md --results all` | `--format md --result all` |
| `src/routes/hsql_features.svelte:9` | `hsql -P prod --results all` | `hsql -P prod --result all` |

`--result` is the worse of the two: it is one character from the truth and the error names the right flag, so a careless reader learns the CLI is unreliable rather than that the docs are.

Both corrected command lines were run against hsql 2.11 before this PR: `--format parquet -o` writes the file, and `--format md --result all` prints every result set. Companion to [tconbeer/harlequin#1089](https://github.com/tconbeer/harlequin/pull/1089), which fixes the same flags in the packaged `hsql` README and adds the unit test that catches them — this repo has no test runner to carry that guard yet, and getting one is M3's PR 7.

Found by running that guard's extractor over these two files; it reports nothing else wrong on either. `pnpm lint` and `pnpm build` both pass (the one eslint warning is pre-existing, in `tweets.svelte`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsKz7zf2oB5cGmLUviuRLv

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsKz7zf2oB5cGmLUviuRLv)_