### PR TITLE
Serve the vendored artifacts, and /schemas/config/v1.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,7 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Vendored from tconbeer/harlequin by its release workflow, and pinned by
+# static/artifacts/manifest.json: reformatting them breaks the digests.
+/static/artifacts

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,7 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# Vendored from tconbeer/harlequin by its release workflow, and pinned by
+# static/artifacts/manifest.json: reformatting them breaks the digests.
+/static/artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,20 @@ There are no tests. `pnpm lint` runs as a pre-commit hook (`@fastify/pre-commit`
 - **Adapter star counts** — `docsMenu` entries carry an optional `repo`, keyed by the first slug segment; `+page.ts` looks it up by topic and fetches the GitHub badge. Documenting a new third-party adapter means setting `repo` on its entry, or the stars/forks badge won't render.
 - **Public API** — `/api/docs/v1` serves the menu as JSON (prerendered, CORS-open, `topics` — each with the `parent` topic it nests inside — plus a flat `pages` list in sidebar order); `/api/docs` redirects there via `vercel.json`. Nothing on the site consumes it — it exists for external callers, so changing its shape is a breaking change in a way the sidebar no longer is.
 
+### Vendored artifacts
+
+`static/artifacts/` holds files generated in [`tconbeer/harlequin`](https://github.com/tconbeer/harlequin) and copied here by that repo's release workflow, which opens a PR against this one. **Never edit them by hand** — the source of truth is the wheel, and the next release will overwrite the change.
+
+- **`manifest.json`** records the `harlequin` version each copy came from, the path in that repo it was generated from, and the size and SHA-256 of every file beside it.
+- **The manifest is checked at build time** — `src/lib/server/artifacts.ts` reads the directory and throws (failing the build) if a file the manifest names is missing, if a file is present that the manifest does not name, or if any file's bytes do not hash to what the manifest recorded. An automated PR that arrives truncated or hand-edited fails rather than serving an agent a wrong answer.
+- **The files are served verbatim.** They are under `static/`, so they are also public as-is at `/artifacts/…` (CORS-open via `vercel.json`); a route that serves one serves the committed bytes, never a re-serialization.
+
+### Schemas
+
+`/schemas/config/v1.json` serves the vendored `config-v1.json` as `application/schema+json` (prerendered, CORS-open; the content type comes from `vercel.json`, because Vercel serves a prerendered file by extension and does not carry a build-time response header over).
+
+Every config schema `harlequin` has generated since 2.10 carries `https://harlequin.sh/schemas/config/v1.json` as its `$id`, so **the path is not ours to rename** — editors and validators dereference it, and `$ref`s resolve against it. The route asserts at build time that the vendored document's `$id` is the URL it is served under.
+
 ### Blog
 
 `src/blog/*.md` with `title`, `publishedAt`, and `lede` frontmatter; `src/routes/api/blog/+server.ts` globs and sorts them by date descending. Same rendering pipeline as docs.

--- a/src/lib/server/artifacts.ts
+++ b/src/lib/server/artifacts.ts
@@ -1,0 +1,108 @@
+/**
+ * The vendored artifacts.
+ *
+ * `static/artifacts/` holds files that are *generated* in `tconbeer/harlequin`
+ * and copied here by that repo's release workflow, which opens a PR against
+ * this one. Nothing in this repo edits them by hand: the source of truth is the
+ * wheel, and `manifest.json` records which release each copy came from.
+ *
+ * Vendoring rather than fetching at build time keeps the build hermetic — a
+ * network blip cannot fail a deploy, and the worst failure mode is a page that
+ * is a release behind rather than a page that is not there.
+ */
+
+// The files are `?raw` rather than JSON imports because the routes serve these
+// bytes verbatim: the digests in the manifest are over the file as committed,
+// and re-serializing a parsed object would not reproduce them.
+const sources = import.meta.glob("/static/artifacts/**/*", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+export type ArtifactFile = {
+  // Path relative to `static/artifacts/`, e.g. "references/config.md".
+  path: string;
+  // The path in `tconbeer/harlequin` the file was generated from.
+  source: string;
+  bytes: number;
+  sha256: string;
+};
+
+export type ArtifactManifest = {
+  // The `harlequin` release these artifacts were published from.
+  version: string;
+  generated_by: string;
+  files: ArtifactFile[];
+};
+
+function read(path: string): string {
+  const source = sources[`/static/artifacts/${path}`];
+  if (source === undefined) {
+    throw new Error(`No vendored artifact at static/artifacts/${path}`);
+  }
+  return source;
+}
+
+export const manifest = JSON.parse(read("manifest.json")) as ArtifactManifest;
+
+/** One vendored artifact, verbatim, by its path in the manifest. */
+export function artifact(path: string): string {
+  return read(path);
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * The artifacts arrive in an automated PR, so the build checks that the PR is
+ * internally consistent before it can go out: every file the manifest names is
+ * here, every file here is named by the manifest, and the bytes are the ones
+ * the release hashed. A truncated copy or a hand-edit is otherwise a silent
+ * wrong answer to whoever reads it.
+ */
+export async function assertArtifactsMatchManifest() {
+  const unlisted = new Set(
+    Object.keys(sources)
+      .map((path) => path.slice("/static/artifacts/".length))
+      .filter((path) => path !== "manifest.json"),
+  );
+
+  const problems: string[] = [];
+  for (const file of manifest.files) {
+    unlisted.delete(file.path);
+    if (!(`/static/artifacts/${file.path}` in sources)) {
+      problems.push(`${file.path}: named by the manifest, not on disk`);
+      continue;
+    }
+    // The digests are over the bytes; `?raw` hands back a decoded string.
+    const bytes = new TextEncoder().encode(read(file.path));
+    if (bytes.byteLength !== file.bytes) {
+      problems.push(
+        `${file.path}: manifest says ${file.bytes} bytes, file is ${bytes.byteLength}`,
+      );
+      continue;
+    }
+    const digest = await sha256(bytes);
+    if (digest !== file.sha256) {
+      problems.push(
+        `${file.path}: manifest says sha256 ${file.sha256}, file is ${digest}`,
+      );
+    }
+  }
+
+  for (const path of [...unlisted].sort()) {
+    problems.push(`${path}: on disk, not named by the manifest`);
+  }
+
+  if (problems.length) {
+    throw new Error(
+      `static/artifacts does not match its manifest (vendored from harlequin ` +
+        `${manifest.version}):\n  ${problems.join("\n  ")}`,
+    );
+  }
+}

--- a/src/routes/schemas/config/v1.json/+server.ts
+++ b/src/routes/schemas/config/v1.json/+server.ts
@@ -1,0 +1,45 @@
+import { artifact, assertArtifactsMatchManifest } from "$lib/server/artifacts";
+
+// Static: the schema only changes when a harlequin release vendors a new copy,
+// so this is a file on the CDN with no cold start and no way to fail at request
+// time.
+export const prerender = true;
+
+// Every schema `harlequin` has generated since 2.10 carries this as its `$id`,
+// which is why this route exists and why its path is not ours to rename.
+const SCHEMA_ID = "https://harlequin.sh/schemas/config/v1.json";
+
+/**
+ * The artifact is served verbatim, so the only thing worth checking is that it
+ * is the document it claims to be: valid JSON, and self-identifying as the URL
+ * a reader dereferenced to get here. A schema served under an `$id` it does not
+ * carry is worse than a 404 — a validator resolves `$ref`s against the `$id`.
+ */
+function schema(): string {
+  const source = artifact("config-v1.json");
+  const parsed = JSON.parse(source);
+  if (parsed.$id !== SCHEMA_ID) {
+    throw new Error(
+      `static/artifacts/config-v1.json has $id ${parsed.$id}, but this route ` +
+        `serves ${SCHEMA_ID}`,
+    );
+  }
+  return source;
+}
+
+export async function GET() {
+  await assertArtifactsMatchManifest();
+
+  return new Response(schema(), {
+    headers: {
+      // In production these come from vercel.json: the route prerenders to a
+      // static file, and Vercel types it by extension rather than carrying a
+      // build-time response header over. They are set here for the dev server,
+      // and because a route that serves a schema should say so on its own.
+      "Content-Type": "application/schema+json",
+      // Public, unauthenticated, and dereferenced by validators in browsers.
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,17 @@
         { "key": "Content-Type", "value": "application/json; charset=utf-8" },
         { "key": "Access-Control-Allow-Origin", "value": "*" }
       ]
+    },
+    {
+      "source": "/schemas/(.*)",
+      "headers": [
+        { "key": "Content-Type", "value": "application/schema+json" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/artifacts/(.*)",
+      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
     }
   ]
 }


### PR DESCRIPTION
M3 PR 6 — "`/schemas/config/v1.json`, and the artifacts directory. The vendored files and the routes that serve them" ([technical plan §4](https://github.com/tconbeer/harlequin/blob/main/docs/plans/m3-hsql-technical-plan.md)). The vendored files landed in #154; this is the routes and the directory's contract.

## Why

Every config schema `harlequin` has generated since 2.10 carries

```json
"$id": "https://harlequin.sh/schemas/config/v1.json"
```

and that URL has 404ed on this site for three releases — there was no route and no file under `schemas/` (§1.5). A schema whose `$id` does not resolve is worse than an undocumented one: an editor or validator that dereferences it to resolve a `$ref` gets an HTML 404 page back.

## What

- **`/schemas/config/v1.json`** — prerendered, serving the vendored `config-v1.json` byte for byte as `application/schema+json`, CORS-open. It asserts at build time that the document's `$id` is the URL it is served under; serving a schema under an identifier it does not carry is the one failure a consumer cannot detect for itself.
- **`src/lib/server/artifacts.ts`** — reads `static/artifacts/` (`?raw`, so the bytes served are the bytes hashed) and checks the directory against its `manifest.json`: every file named is present, every file present is named, and every file's length and SHA-256 match what the release recorded. The artifacts arrive by automated PR from `release.yml`, so the build is where a truncated or hand-edited copy has to stop. Same build-time-guard pattern `/api/docs/v1` already uses for the docs menu. Web Crypto rather than `node:crypto`, so no `@types/node` dependency.
- **`vercel.json`** — types `/schemas/(.*)` as `application/schema+json` and opens CORS on it and on `/artifacts/(.*)`. The content type has to live there: a prerendered route is a static file, and Vercel types it by extension rather than carrying a build-time response header over.
- **`.prettierignore` / `.eslintignore`** — a bug #154 introduced. `pnpm format` reformats four of the vendored markdown files, which breaks their digests, and `pnpm lint` — the pre-commit hook — has been failing on them since they were committed. Both now ignore `/static/artifacts`.
- **`AGENTS.md`** — "Vendored artifacts" and "Schemas": never hand-edit, the manifest is checked at build time, the path is not ours to rename.

Nothing user-visible on the site changes; no page links here yet. The reference page that renders `hsql-reference.md` is PR 12's.

## Verification

- `pnpm build` succeeds, and the prerendered `/schemas/config/v1.json` diffs identical against `static/artifacts/config-v1.json`.
- Each guard was exercised by tampering with a vendored file — wrong byte count, wrong SHA-256 at matching length, and an unlisted extra file each fail the build with the intended message. Artifacts restored after.
- Dev server returns `content-type: application/schema+json` and `access-control-allow-origin: *`; `/artifacts/SKILL.md` returns `text/markdown`.
- `pnpm lint` passes (one pre-existing warning in `tweets.svelte`). `pnpm check` sits at its pre-existing 15 errors, unchanged from `main` and none in new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPnwzMzosNQ2HzAXR6BBDC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPnwzMzosNQ2HzAXR6BBDC)_