### PR TITLE
Document the H2 community adapter

### DIFF
--- a/src/docs/adapters.md
+++ b/src/docs/adapters.md
@@ -35,3 +35,4 @@ Community adapters are created and maintained by other members of the Harlequin 
 - [Cassandra](/docs/cassandra), contributed by [Vadim Khitrin](https://github.com/vkhitrin)
 - [NebulaGraph](/docs/nebulagraph), contributed by [Wey Gu](https://github.com/wey-gu)
 - [Exasol](/docs/exasol), contributed by [Nicola Coretti](https://github.com/Nicoretti)
+- [H2](/docs/h2), contributed by [clang-engineer](https://github.com/clang-engineer)

--- a/src/docs/h2.md
+++ b/src/docs/h2.md
@@ -1,0 +1,53 @@
+---
+title: "Adapter: H2"
+description: "Install the H2 adapter and connect Harlequin to embedded or server-based H2 databases over JDBC."
+---
+
+The H2 adapter was contributed by community member [clang-engineer](https://github.com/clang-engineer).
+
+See the [harlequin-h2 repository](https://github.com/clang-engineer/harlequin-h2) for the most up-to-date documentation.
+
+## Installation
+
+Install the adapter into the same environment as Harlequin:
+
+```bash
+uv tool install harlequin --with harlequin-h2
+```
+
+The adapter requires a Java runtime compatible with your H2 version and an H2 2.x JDBC driver JAR. If the adapter does not discover the JAR automatically, provide its path with `--jar` or the `H2_JAR` environment variable.
+
+## Usage
+
+Select the adapter with `-a h2` and pass an H2 JDBC URL.
+
+### Embedded file database
+
+```bash
+harlequin -a h2 -U sa \
+  "jdbc:h2:file:/path/to/database;AUTO_SERVER=TRUE;IFEXISTS=TRUE"
+```
+
+`AUTO_SERVER=TRUE` allows Harlequin and another JVM process to share the file. `IFEXISTS=TRUE` prevents a mistyped path from creating a new empty database.
+
+### Embedded memory database
+
+```bash
+harlequin -a h2 "jdbc:h2:mem:demo"
+```
+
+The named database normally exists until its last connection closes. Add `;DB_CLOSE_DELAY=-1` only when it must survive connection closure; H2 then retains it until `SHUTDOWN` or process exit.
+
+### TCP server
+
+```bash
+harlequin -a h2 -U sa "jdbc:h2:tcp://localhost/~/demo"
+```
+
+## Options
+
+- `--jar PATH`: Path to the H2 JDBC driver JAR.
+- `-U, --user USER`: H2 username; defaults to `sa`.
+- `--password PASSWORD`: H2 password; defaults to an empty string.
+
+Prefer a protected Harlequin profile or an environment-variable reference for passwords because command-line arguments may be visible to other local processes.

--- a/src/lib/docs_menu.ts
+++ b/src/lib/docs_menu.ts
@@ -71,6 +71,11 @@ export const docsMenu: DocsMenuItem[] = [
       },
       { title: "Adapter: ODBC", slug: "odbc", repo: "tconbeer/harlequin-odbc" },
       {
+        title: "Adapter: H2",
+        slug: "h2",
+        repo: "clang-engineer/harlequin-h2",
+      },
+      {
         topic: "Adapter: BigQuery",
         slug: "bigquery",
         repo: "joshtemple/harlequin-bigquery",

--- a/src/lib/docs_menu.ts
+++ b/src/lib/docs_menu.ts
@@ -71,11 +71,6 @@ export const docsMenu: DocsMenuItem[] = [
       },
       { title: "Adapter: ODBC", slug: "odbc", repo: "tconbeer/harlequin-odbc" },
       {
-        title: "Adapter: H2",
-        slug: "h2",
-        repo: "clang-engineer/harlequin-h2",
-      },
-      {
         topic: "Adapter: BigQuery",
         slug: "bigquery",
         repo: "joshtemple/harlequin-bigquery",
@@ -130,6 +125,11 @@ export const docsMenu: DocsMenuItem[] = [
         title: "Adapter: Exasol",
         slug: "exasol",
         repo: "Nicoretti/harlequin-exasol",
+      },
+      {
+        title: "Adapter: H2",
+        slug: "h2",
+        repo: "clang-engineer/harlequin-h2",
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add installation and usage documentation for the H2 JDBC adapter
- list H2 among community adapters
- add the adapter to the documentation sidebar with repository metadata

## Testing

- `pnpm lint`
- `pnpm test` (813 tests)
- `pnpm build`

All checks ran under Node.js 22. Lint reports the existing unused-variable warning in `src/routes/tweets.svelte`; there are no lint errors.